### PR TITLE
Fix the post not found issue

### DIFF
--- a/posts.md
+++ b/posts.md
@@ -8,7 +8,7 @@ permalink: /posts/
 <div class="posts-index">
 	{% for post in site.posts %}
 		<li>
-			<a href="{{ post.url}}">{{ post.title }}</a>
+			<a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
 		</li>
 	{% endfor %}
 </div>


### PR DESCRIPTION
Fixes #7 - the baseurl was missing from the post links in the index
file.  The index file for posts is generated by Jekyll from a Markdown
file called posts.md in the site root folder (openwis-documentation).
