### PR TITLE
Fix Kanban items not found

### DIFF
--- a/_kanban/index.html
+++ b/_kanban/index.html
@@ -34,9 +34,9 @@ title: Kanban Board
 					</div>
 					<div class="kanTaskDesc">
 							 {% if kanCard.content.size > kanMaxChars %}
-								 {{ kanCard.content | truncate: kanMaxChars }}<a href="{{ kanCard.url }}" target=_blank><br><br><em>more</em></a>
+								 {{ kanCard.content | truncate: kanMaxChars }}<a href="{{ kanCard.url | prepend: site.baseurl  }}" target=_blank><br><br><em>more</em></a>
 							 {% else %}
-									{{ kanCard.content }}<a href="{{ kanCard.url }}" target=_blank><em>show</em></a>
+									{{ kanCard.content }}<a href="{{ kanCard.url | prepend: site.baseurl  }}" target=_blank><em>show</em></a>
 							 {% endif %}
 					</div>
 				</details>


### PR DESCRIPTION
Fixes #6 - baseurl was missing from the links on the Kanban card
(show/more) so you got 404 when clicked.  The links are setup when
Jekyll processes the index.html file within the _kanban directory.
