### PR TITLE
Fix Favicon not showing on gh-pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="shortcut icon" href="/favicon.ico?r=31241" type="image/x-icon">
-  <link rel="icon" href="/favicon.ico?r=31241" type="image/x-icon">
+  <link rel="shortcut icon" href="{{ "/favicon.ico?r=31241" | prepend: site.baseurl type="image/x-icon"}}">
+  <link rel="icon" href="{{ "/favicon.ico?r=31241" | prepend: site.baseurl type="image/x-icon"}}">
 
 </head>


### PR DESCRIPTION
Fixes #8 - baseurl missing from head.html
