### PR TITLE
Edit page on gh-pages

### DIFF
--- a/_backlog/OpenWIS-Backlog-000166.md
+++ b/_backlog/OpenWIS-Backlog-000166.md
@@ -1,4 +1,4 @@
---
+---
 layout: backlog
 title: Link from backlog item to GitHub to edit
 kanCategory: backlog
@@ -26,6 +26,17 @@ As a start, let's just get the address of the file on GitHub displayed in the fo
 
 ##Analysis
 
+The url of this page on the local jekyll server site is: http://127.0.0.1:4000/openwis-documentation/backlog/OpenWIS-Backlog-000166.html
 The url of this page on this openwis-documentation site page is: http://openwis.github.io/openwis-documentation/backlog/OpenWIS-Backlog-000166.html
 
-The url of the page on GitHub that corresponds to this openwis-documentation site page is: https://github.com/OpenWIS/openwis-documentation/blob/gh-pages/_backlog/OpenWIS-Backlog-000166.md
+The url of the EDITOR page on GitHub that corresponds to this openwis-documentation site page is: https://github.com/OpenWIS/openwis-documentation/blob/gh-pages/_backlog/OpenWIS-Backlog-000166.md
+
+All we want to do is open the editor page on GitHub.  We are not offering the ability to edit the local version of the file, because you would do that through your favourite editor or toolset.
+
+For this page:
+ site.url resolves to http://openwis.github.io
+ site.baseurl resolves to /openwis-documentation
+ page.path resolves to _backlog/OpenWIS-Backlog-000166.md
+
+ So the simplest approach would be to concatenate the string constant https://github.com/OpenWIS/openwis-documentation/blob/gh-pages/
+ with the page.path and provide that as a link in the footer of the page.

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,9 @@ baseurl: "/openwis-documentation"
 # UNCOMMENT next line before publishing to GitHub!!!  REcomment to run local tests with Jekyll serve
 url: "http://openwis.github.io"
 
+# gh-pages-editor-url is the main part of the web address we need to link to the GitHub editor to edit the page directly in the gh-pages source
+gh-pages-editor-url: "https://github.com/OpenWIS/openwis-documentation/blob/gh-pages/"
+
 # Build settings
 markdown: kramdown
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,9 @@
 <footer class="site-footer">
 
   <div class="wrapper">
+    <div>
+      <p><a class="gh-pages-editor-link" href="{{ page.path | prepend: site.gh-pages-editor-url }}">Edit this page on gh-pages</a></p>
+    </div>
 
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
@@ -14,12 +17,6 @@
         <p><a rel="license" href="//creativecommons.org/licenses/by/4.0/" title="Creative Commons Attribution 4.0 International license"><img src="https://licensebuttons.net/l/by/4.0/88x31.png" alt="License"/></a></p>
         <p><small>Except where otherwise noted, content on <span href="http://openwis.io">this site</span> is licensed under a <a rel="license" href="//creativecommons.org/licenses/by/4.0/"> Creative Commons Attribution 4.0 International license</a>.</small></p>
       </div>
-    </div>
-
-    <div>
-      <p>{{ page.path }}</p>
-      <p>{{ site.url }}</p>
-      <p>{{ baseurl }}</p>
     </div>
 
   </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -277,3 +277,13 @@ td, th { text-align: left ; padding: 10px }
  */
 .clear {clear: left;
     }
+
+/**
+  * gh-pages-editor-link - additional style defined by Paul Rogers to style the gh-pages-editor-link
+  */
+.gh-pages-editor-link {font-style: normal;
+        padding: 0.5em; font-size: 80%;
+        border-width: 0.2em; border-style: solid; border-color: SteelBlue;
+        background-color: Silver;
+        border-radius: 5px;
+        }


### PR DESCRIPTION
A link now appears in the footer that opens the gh-pages page source for
editing in the GitHub editor .
