### PR TITLE
Show which Kanban tasks are in progress

### DIFF
--- a/_kanban/index.html
+++ b/_kanban/index.html
@@ -19,8 +19,14 @@ title: Kanban Board
 	<h2>{{ j }}</h2>
 		{% for kanCard in site.kanban %}
 			  {% if kanCard.kanCategory == j %}
+					{% if kanCard.kanSubCategory == "in-progress" %}
+						{% assign kanTask-in-progress-summary = "kanTask-in-progress-style" %}
+					{% else %}
+						{% assign kanTask-in-progress-summary = "kanTask-pending-style" %}
+					{% endif %}
+
 				<details class="kanCard">
-					<summary><strong>{{ kanCard.kanBacklog | append: '. ' | append: kanCard.title }}</strong></summary>
+					<summary class={{ kanTask-in-progress-summary }}><strong class="kanTask-board-title">{{ kanCard.kanBacklog | append: '. ' | append: kanCard.title }}</strong></summary>
 					<div class="kanTask">
 						<p>
 							 {% if kanCard.kanPullReq %} pull-req#{{ kanCard.kanPullReq }}{% endif %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -212,6 +212,14 @@ table { border-collapse: collapse }
 table, td, th { border: 1px solid #e8e8e8 }
 td, th { text-align: left ; padding: 10px }
 
+/**
+ * task-in-progress / task-pending color - additional styles defined by Paul Rogers to highlight Kanban tasks in progress
+ */
+.kanTask-in-progress-style { color:Red; }
+
+.kanTask-pending-style { color:Black; }
+
+.kanTask-board-title { color:SteelBlue; }
 
 
 /**


### PR DESCRIPTION
The triangular drop-down pointer against each Kanban task title is now
coloured red if the task is in progress and black otherwise.  I also
made the task titles themselves SteelBlue so that the Kanban board looks
distinct from the Backlog board to avoid any confusion.
