### PR TITLE
Fix truncation mid-tag

### DIFF
--- a/_backlog/index.html
+++ b/_backlog/index.html
@@ -58,7 +58,16 @@ title: Backlog
 						</div>
 						<div class="kanTaskDesc">
 								 {% if kanCard.content.size > kanMaxChars %}
-								   {{ kanCard.content | truncate: kanMaxChars }}<a href="{{ kanCard.url | prepend: site.baseurl }}" target=_blank><br><br><em>more</em></a>
+								 		{% assign kanParas = kanCard.content | split: "</p>" %}
+								 		{% assign kanChars = 0 %}
+								 		{% for p in kanParas %}
+ 											{{ p }}
+								 			{% assign kanChars = kanChars | plus: p.size %}
+											{% if kanChars >= kanMaxChars %}
+												<a href="{{ kanCard.url | prepend: site.baseurl }}" target=_blank><br><br><em>more</em></a>
+												{% break %}
+											{% endif %}
+										{% endfor %}
 								 {% else %}
 								 		{{ kanCard.content }}<a href="{{ kanCard.url | prepend: site.baseurl }}" target=_blank><em>show</em></a>
 								 {% endif %}

--- a/_kanban/index.html
+++ b/_kanban/index.html
@@ -39,11 +39,20 @@ title: Kanban Board
 						 </p>
 					</div>
 					<div class="kanTaskDesc">
-							 {% if kanCard.content.size > kanMaxChars %}
-								 {{ kanCard.content | truncate: kanMaxChars }}<a href="{{ kanCard.url | prepend: site.baseurl  }}" target=_blank><br><br><em>more</em></a>
-							 {% else %}
-									{{ kanCard.content }}<a href="{{ kanCard.url | prepend: site.baseurl  }}" target=_blank><em>show</em></a>
-							 {% endif %}
+						{% if kanCard.content.size > kanMaxChars %}
+							 {% assign kanParas = kanCard.content | split: "</p>" %}
+							 {% assign kanChars = 0 %}
+							 {% for p in kanParas %}
+								 {{ p }}
+								 {% assign kanChars = kanChars | plus: p.size %}
+								 {% if kanChars >= kanMaxChars %}
+									 <a href="{{ kanCard.url | prepend: site.baseurl }}" target=_blank><br><br><em>more</em></a>
+									 {% break %}
+								 {% endif %}
+							 {% endfor %}
+						{% else %}
+							 {{ kanCard.content }}<a href="{{ kanCard.url | prepend: site.baseurl }}" target=_blank><em>show</em></a>
+						{% endif %}
 					</div>
 				</details>
 				{% endif %}


### PR DESCRIPTION
Now truncates only at end of a para, after </p> tag.
