### PR TITLE
adding new forum link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
                 <li class="no-link">Developers</li>
 		<li><a href="{{ site.data.howto.subpath | prepend: site.baseurl }}">How-to Instructions</a></li>
                 <li><a href="{{ site.data.posts.subpath | prepend: site.baseurl }}">Github Posts Archive</a></li>
-		<li><a href="https://www.openwis.io/cms/forum" target="_blank">Forum*</a></li>
+		<li><a href="https://discourse.dev2.openwis.io/" target="_blank">Forum*</a></li>
             </ul>
          </div>          
          

--- a/structure/governance.html
+++ b/structure/governance.html
@@ -16,6 +16,6 @@ title: Governance
     <li>the <a href="{{ "/structure/technical-committee.html" | prepend: site.baseurl }}">Technical Committee</a>.</li>
   </ul>
 
-  <p>We also provide a <a href="http://openwis.io/cms/index.php/forum" target="_blank">discussion forum</a>.</p>
+  <p>We also provide a <a href="https://discourse.dev2.openwis.io" target="_blank">discussion forum</a>.</p>
 
 </div>


### PR DESCRIPTION
I have updated the forum links on the website to go to: discourse.dev2.openwis.io