### PR TITLE
Added new internal rule to (almost) allow default 2-year tenure 

### DIFF
--- a/rules/7-management-structure-and-qualification-of-officers.md
+++ b/rules/7-management-structure-and-qualification-of-officers.md
@@ -13,7 +13,8 @@ contents : [
     ["#rule-7.5", "Rule 7.5"],
     ["#rule-7.6", "Rule 7.6"],
     ["#rule-7.7", "Rule 7.7"],
-    ["#rule-7.8", "Rule 7.8"]
+    ["#rule-7.8", "Rule 7.8"],
+    ["#rule-7.9", "Rule 7.9"]
 ]
 ---
 
@@ -52,5 +53,9 @@ The Steering Committee shall appoint a Contributor as the **Project Leader** for
 <h2 id="rule-7.8">Rule 7.8</h2>
 
 The Technical Committee shall operate as a cross-Project technical architecture / design authority body that provides technical oversight; (i) monitoring, guiding, and influencing the software architectures used by Projects, (ii) new Project mentoring, and (iii) maintaining and revising the [Technical Rules]({{ "/tr/" | prepend: site.baseurl }}) of the Association.
+
+<h2 id="rule-7.9">Rule 7.9</h2>
+
+In the event that a sitting SC Chair and/or SC Vice-Chair expresses their intention to stand for re-election under [Rule 7.5](#rule-7.5) and no other candidate wishes to stand against him or her, he or she may be re-elected to the role unopposed, provided that such re-election does not breach the term limit of four consecutive years laid down in [Article 13.6]({{ "/articles/13-steering-committee.html#article-13.6" | prepend: site.baseurl }}) of the Articles of Association.
 
 [previous: TITLE 6]({{ "/rules/6-membership-and-partnership-fees-rights-privileges-and-obligations.html" | prepend: site.baseurl }}) \| [next: TITLE 8]({{ "/rules/8-meetings.html" | prepend: site.baseurl }})


### PR DESCRIPTION
Fixes #265 

As per discussion in ISSUE #265, adding new rule.

New rule added as number 7.9 as renumbering the rules would be
problematic (cause other references to rules 7.6-7.8 to become wrong!)

Text proposed by Michael Robbins based on his assessment:

“””
I see from the minutes of the March 2016 SC that the following
resolution was passed:

> RESOLUTION-SC-2016-01:Resolution: vote: 7-0 in favour - Amend
Internal Rules to say that default tenure is 2 years unless others want
to stand for election
>
> To change the default tenure of the SC Chair and SC Vice-Chair from 1
year to 2 years.

I’m afraid this is ultra vires as the term of office is set down in the
Article of Association (Article 13.6) as 12 months. It cannot be
changed without changing the Articles. I’m not sure this is really
necessary though – the “long stop” on consecutive years served is four
years. If an SC Chair / Vice Chair wants to continue in office and
there is a unanimous view that they should do so, then it would make
sense for them to be put up unopposed each year and voted back in as a
matter of course. You could probably have an internal rule along the
following lines…
“””