### PR TITLE
Removed rejected internal rule 7.9 that got accidentally included

### DIFF
--- a/rules/7-management-structure-and-qualification-of-officers.md
+++ b/rules/7-management-structure-and-qualification-of-officers.md
@@ -14,8 +14,7 @@ contents : [
     ["#rule-7.6", "Rule 7.6"],
     ["#rule-7.7", "Rule 7.7"],
     ["#rule-7.8", "Rule 7.8"],
-    ["#rule-7.9", "Rule 7.9"],
-    ["#rule-7.10", "Rule 7.10"]
+    ["#rule-7.9", "Rule 7.9"]
 ]
 ---
 
@@ -56,10 +55,6 @@ The Steering Committee shall appoint a Contributor as the **Project Leader** for
 The Technical Committee shall operate as a cross-Project technical architecture / design authority body that provides technical oversight; (i) monitoring, guiding, and influencing the software architectures used by Projects, (ii) new Project mentoring, and (iii) maintaining and revising the [Technical Rules]({{ "/tr/" | prepend: site.baseurl }}) of the Association.
 
 <h2 id="rule-7.9">Rule 7.9</h2>
-
-In the event that a sitting SC Chair and/or SC Vice-Chair expresses their intention to stand for re-election under [Rule 7.5](#rule-7.5) and no other candidate wishes to stand against him or her, he or she may be re-elected to the role unopposed, provided that such re-election does not breach the term limit of four consecutive years laid down in [Article 13.6]({{ "/articles/13-steering-committee.html#article-13.6" | prepend: site.baseurl }}) of the Articles of Association.
-
-<h2 id="rule-7.10">Rule 7.10</h2>
 
 The composition and responsibilities of the governance bodies within the OpenWIS&reg; Association are summarised in [this supplement]({{ site.baseurl | prepend: site.url }}/rules2/2017-12-06-OpenWIS-Governance-Roles-Responsibilities.html) to the internal rules.
 


### PR DESCRIPTION
Internal Rule relating to re-election of SC Chair / Vice-Chair was rejected during the 2018 Board Meeting. Unfortunately, the commit with this Rule change was also rolled up in a PR for another rule change. This commit removes the Rule (7.9 as was) and renumbers the rules accordingly.

The text of the deleted rule was:

```
In the event that a sitting SC Chair and/or SC Vice-Chair expresses their intention to stand for re-election under [Rule 7.5](#rule-7.5) and no other candidate wishes to stand against him or her, he or she may be re-elected to the role unopposed, provided that such re-election does not breach the term limit of four consecutive years laid down in [Article 13.6]({{ "/articles/13-steering-committee.html#article-13.6" | prepend: site.baseurl }}) of the Articles of Association.
```

The original closed PR with this rule change is here: https://github.com/OpenWIS/openwis-documentation/pull/337